### PR TITLE
User登録フォームの更新 

### DIFF
--- a/backend/app/Http/Controllers/User/Auth/RegisteredUserController.php
+++ b/backend/app/Http/Controllers/User/Auth/RegisteredUserController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
+use App\Models\Prefecture;
 
 class RegisteredUserController extends Controller
 {
@@ -20,7 +21,9 @@ class RegisteredUserController extends Controller
      */
     public function create()
     {
-        return view('user.auth.register');
+        $prefectures = Prefecture::all();
+
+        return view('user.auth.register', compact('prefectures'));
     }
 
     /**
@@ -43,6 +46,11 @@ class RegisteredUserController extends Controller
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
+            'age' => $request->age,
+            'gender' => $request->gender,
+            'prefecture_id' => $request->prefecture_id,
+            'years_of_experience' => $request->years_of_experience,
+            'through' => $request->through,
         ]);
 
         event(new Registered($user));

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -24,6 +24,11 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'age',
+        'gender',
+        'prefecture_id',
+        'years_of_experience',
+        'through'
     ];
 
     /**

--- a/backend/app/Providers/RouteServiceProvider.php
+++ b/backend/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/dashboard';
+    public const HOME = '/roads';
     public const OWNER_HOME = '/owner/dashboard';
     public const ADMIN_HOME = '/admin/dashboard';
 

--- a/backend/resources/views/layouts/user-navigation.blade.php
+++ b/backend/resources/views/layouts/user-navigation.blade.php
@@ -41,7 +41,7 @@
                             <x-dropdown-link :href="route('user.logout')"
                                     onclick="event.preventDefault();
                                                 this.closest('form').submit();">
-                                {{ __('Log Out') }}
+                                {{ __('ログアウト') }}
                             </x-dropdown-link>
                         </form>
                     </x-slot>
@@ -83,7 +83,7 @@
                     <x-responsive-nav-link :href="route('user.logout')"
                             onclick="event.preventDefault();
                                         this.closest('form').submit();">
-                        {{ __('Log Out') }}
+                        {{ __('ログアウト') }}
                     </x-responsive-nav-link>
                 </form>
             </div>

--- a/backend/resources/views/user/auth/login.blade.php
+++ b/backend/resources/views/user/auth/login.blade.php
@@ -18,14 +18,14 @@
 
             <!-- Email Address -->
             <div>
-                <x-label for="email" :value="__('Email')" />
+                <x-label for="email" :value="__('メールアドレス')" />
 
                 <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autofocus />
             </div>
 
             <!-- Password -->
             <div class="mt-4">
-                <x-label for="password" :value="__('Password')" />
+                <x-label for="password" :value="__('パスワード')" />
 
                 <x-input id="password" class="block mt-1 w-full"
                                 type="password"
@@ -37,19 +37,19 @@
             <div class="block mt-4">
                 <label for="remember_me" class="inline-flex items-center">
                     <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" name="remember">
-                    <span class="ml-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
+                    <span class="ml-2 text-sm text-gray-600">{{ __('ログインしたままにする') }}</span>
                 </label>
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 @if (Route::has('user.password.request'))
                     <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('user.password.request') }}">
-                        {{ __('Forgot your password?') }}
+                        {{ __('パスワードを忘れた場合') }}
                     </a>
                 @endif
 
                 <x-button class="ml-3">
-                    {{ __('Log in') }}
+                    {{ __('ログイン') }}
                 </x-button>
             </div>
         </form>

--- a/backend/resources/views/user/auth/register.blade.php
+++ b/backend/resources/views/user/auth/register.blade.php
@@ -14,21 +14,21 @@
 
             <!-- Name -->
             <div>
-                <x-label for="name" :value="__('Name')" />
+                <x-label for="name" :value="__('名前 ※必須')" />
 
                 <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus />
             </div>
 
             <!-- Email Address -->
             <div class="mt-4">
-                <x-label for="email" :value="__('Email')" />
+                <x-label for="email" :value="__('メールアドレス ※必須')" />
 
                 <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required />
             </div>
 
             <!-- Password -->
             <div class="mt-4">
-                <x-label for="password" :value="__('Password')" />
+                <x-label for="password" :value="__('パスワード ※必須')" />
 
                 <x-input id="password" class="block mt-1 w-full"
                                 type="password"
@@ -38,20 +38,70 @@
 
             <!-- Confirm Password -->
             <div class="mt-4">
-                <x-label for="password_confirmation" :value="__('Confirm Password')" />
+                <x-label for="password_confirmation" :value="__('確認用パスワード ※必須')" />
 
                 <x-input id="password_confirmation" class="block mt-1 w-full"
                                 type="password"
                                 name="password_confirmation" required />
             </div>
 
+            <!-- Age -->
+            <div class="mt-4">
+                <x-label for="age" :value="__('年齢 ※必須')" />
+                <x-input id="age" class="block mt-1 w-full"
+                                type="number"
+                                name="age" required />
+            </div>
+
+            <!-- Gender -->
+            <div class="mt-4">
+                <x-label for="gender" :value="__('性別 ※必須')" />
+                <div class="block mt-1 w-full">
+                    <div class="relative flex justify-around">
+                        <div><input type="radio" name="gender" value="1" class="mr-2" checked>男性</div>
+                        <div><input type="radio" name="gender" value="0" class="mr-2">女性</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Prefecture -->
+            <div class="mt-4">
+                <x-label for="prefecture_id" :value="__('都道府県 ※必須')" />
+                <select name="prefecture_id" id="prefecture_id" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+                    @foreach($prefectures as $prefecture)
+                        <option value="{{ $prefecture->id }}">
+                            {{ $prefecture->name }}
+                        </option>
+                    @endforeach
+                </select>
+            </div>
+
+            <!-- Experience -->
+            <div class="mt-4">
+                <x-label for="years_of_experience" :value="__('バイク歴(年) ※必須')" />
+                <x-input id="years_of_experience" class="block mt-1 w-full"
+                                type="number"
+                                name="years_of_experience" required />
+            </div>
+
+            <!-- Through -->
+            <div class="mt-4">
+                <x-label for="through" :value="__('すり抜け ※必須')" />
+                <div class="block mt-1 w-full">
+                    <div class="relative flex justify-around">
+                        <div><input type="radio" name="through" value="1" class="mr-2" checked>無</div>
+                        <div><input type="radio" name="through" value="0" class="mr-2">有</div>
+                    </div>
+                </div>
+            </div>
+
             <div class="flex items-center justify-end mt-4">
                 <a class="underline text-sm text-gray-600 hover:text-gray-900" href="{{ route('user.login') }}">
-                    {{ __('Already registered?') }}
+                    {{ __('すでに登録している場合') }}
                 </a>
 
                 <x-button class="ml-4">
-                    {{ __('Register') }}
+                    {{ __('登録') }}
                 </x-button>
             </div>
         </form>

--- a/backend/resources/views/user/auth/reset-password.blade.php
+++ b/backend/resources/views/user/auth/reset-password.blade.php
@@ -17,21 +17,21 @@
 
             <!-- Email Address -->
             <div>
-                <x-label for="email" :value="__('Email')" />
+                <x-label for="email" :value="__('メールアドレス')" />
 
                 <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email', $request->email)" required autofocus />
             </div>
 
             <!-- Password -->
             <div class="mt-4">
-                <x-label for="password" :value="__('Password')" />
+                <x-label for="password" :value="__('パスワード')" />
 
                 <x-input id="password" class="block mt-1 w-full" type="password" name="password" required />
             </div>
 
             <!-- Confirm Password -->
             <div class="mt-4">
-                <x-label for="password_confirmation" :value="__('Confirm Password')" />
+                <x-label for="password_confirmation" :value="__('確認用パスワード')" />
 
                 <x-input id="password_confirmation" class="block mt-1 w-full"
                                     type="password"
@@ -40,7 +40,7 @@
 
             <div class="flex items-center justify-end mt-4">
                 <x-button>
-                    {{ __('Reset Password') }}
+                    {{ __('パスワードを再設定') }}
                 </x-button>
             </div>
         </form>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -20,9 +20,8 @@ Route::get('/', function () {
     return view('user.welcome');
 });
 
-Route::resource('roads', RoadController::class);
-    // User登録でage等が入力できないので一時的にコメントアウト
-    // ->middleware('auth:users');
+Route::resource('roads', RoadController::class)
+    ->middleware('auth:users');
 
 Route::get('/dashboard', function () {
     return view('user.dashboard');


### PR DESCRIPTION
# WHY
手動でUser登録ができないため
（Userカラムを追加したのにフォームが合っていない）

# WHAT
/registerのUser登録フォームにage, gender, prefecture_id, years_of_experience, throughを登録できるように変更

## 確認事項
routes/web.php の auth:userをコメントアウトを戻しました。
![スクリーンショット 2022-01-15 9 42 54](https://user-images.githubusercontent.com/85143983/149601900-9074b4e4-736c-455e-926c-ce19e22b818c.png)
![スクリーンショット 2022-01-15 9 43 14](https://user-images.githubusercontent.com/85143983/149601919-cb91dbbd-3b6c-43ae-bec6-83fe9b38251e.png)

